### PR TITLE
Handle initial releases properly

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,9 @@ author            = Kathryn Andersen
 license           = Perl_5
 copyright_holder  = Kathryn Andersen
 
+; DZIL plugins should use the latest code
+[Bootstrap::lib]
+
 ; File Gather ---------------------
 [GatherDir]
 [ReadmeFromPod]


### PR DESCRIPTION
Currently, a release without a tag does not output anything in the CHANGES log.  This is different than say, a release with one tag, which outputs two different versions.  The problem stems from the "git log" command trying to get data from `HEAD..HEAD`.

This fix puts in an exception for the initial release by grabbing the last commit (`HEAD~1..HEAD`) and putting it into the changelog.  This mimics the behavior of first releases when they are among other releases in the changelog.

Also, there's some minor code cleanup here and a dist.ini addition.
