### PR TITLE
Remove unneeded dependency on Moose::Autobox

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitFmtChanges.pm
+++ b/lib/Dist/Zilla/Plugin/GitFmtChanges.pm
@@ -76,7 +76,6 @@ the "subject" of the change.
 =cut
 
 use Moose;
-use Moose::Autobox;
 with 'Dist::Zilla::Role::FileGatherer';
 
 use POSIX qw(strftime);


### PR DESCRIPTION
Turns out no autobox code is actually being used in this module, so you can free up some dependencies and avoid extra problems ( https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5 ) for free =)

