### PR TITLE
Fixes for kwalitee issues

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,8 @@ log_format = * %ai%n  %s
 ; Dist Meta ---------------------
 [GithubMeta]
 [MetaYAML]
+[MetaJSON]
+[MetaProvides::Package]
 
 ; Configure Install ---------------------
 [MakeMaker]

--- a/lib/Dist/Zilla/Plugin/GitFmtChanges.pm
+++ b/lib/Dist/Zilla/Plugin/GitFmtChanges.pm
@@ -75,6 +75,7 @@ the "subject" of the change.
 
 =cut
 
+require 5.6.0;
 use Moose;
 with 'Dist::Zilla::Role::FileGatherer';
 


### PR DESCRIPTION
dzp-GitFmtChanges is my dist this month for the [CPAN PR Challenge](http://cpan-prc.org/).

Here is the first small PR to remove the non-test-related [kwalitee issues](http://cpants.cpanauthors.org/release/RUBYKAT/Dist-Zilla-Plugin-GitFmtChanges-0.005). They are:

- has_meta_json
- meta_yml_declares_perl_version
- meta_yml_has_provides

I hope you find this useful.